### PR TITLE
Supporting Google Storage config file source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,5 @@ bin
 # Local .env file
 .env
 
-config.yml
+/config.yml
 /*.json

--- a/README.md
+++ b/README.md
@@ -3,3 +3,25 @@
 [![Build](https://github.com/dlampsi/a0feed/actions/workflows/build.yml/badge.svg)](https://github.com/dlampsi/a0feed/actions/workflows/build.yml)
 
 A0 Feed is a news translation service or application that processes RSS feed items, translates and sends them to customized destinations (eg Telegam).
+
+## Feeds configuration
+
+Application uses config config file as a feeds configuration source. File can be loaded from local filesystem or Google Cloud Storage.
+
+File path should be specified in the URL format, eg `file:///path/to/config.yml` or `gs://bucket/path/to/config.yml`. <br>
+If config file is not specified, application will try to use `config.yml` file in the current directory.
+
+Config file is a YAML file with the following structure:
+
+```yaml
+feeds:
+  - source: News portal
+    category: Latest
+    url: https://dummyfeed.com/rss
+    translates:
+      - from: fi
+        to: en
+        notify:
+          - type: telegram
+            chat_id: <telegram_chat_id>
+```

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"a0feed/structs"
+	"a0feed/utils/logging"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"strings"
+
+	googleStorage "cloud.google.com/go/storage"
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	UnknownSchemeError error = errors.New("Unknown config file URL scheme")
+)
+
+type ConfigFile struct {
+	Feeds []structs.FeedConfig `yaml:"feeds"`
+}
+
+func Load(ctx context.Context, uri string) (*ConfigFile, error) {
+	logger := logging.FromContext(ctx)
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to parse config uri: %w", err)
+	}
+
+	var result ConfigFile
+
+	var data []byte
+
+	switch parsed.Scheme {
+	case "file":
+		logger.Info("Loading config from filesytsem")
+
+		cfile, err := os.ReadFile(parsed.Path)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to load file: %w", err)
+		}
+		data = cfile
+
+	case "gs":
+		logger.Info("Loading config from Google Storage")
+
+		cl, err := googleStorage.NewClient(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to create google storage client: %w", err)
+		}
+		defer cl.Close()
+
+		bucket := cl.Bucket(parsed.Host)
+
+		gsPath := strings.TrimLeft(parsed.Path, "/")
+		obj := bucket.Object(gsPath)
+
+		rc, err := obj.NewReader(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to read bucket object %s: %w", gsPath, err)
+		}
+		defer rc.Close()
+
+		body, err := io.ReadAll(rc)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to read object from reader: %w", err)
+		}
+		data = body
+
+	default:
+		return nil, UnknownSchemeError
+	}
+
+	if err := yaml.Unmarshal(data, &result); err != nil {
+		return nil, fmt.Errorf("Failed to parse data: %w", err)
+	}
+	return &result, nil
+}

--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -1,0 +1,45 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigFileLoad(t *testing.T) {
+	ctx := context.Background()
+
+	// Current path
+	cpath, err := os.Getwd()
+	require.NoError(t, err)
+	require.NotEmpty(t, cpath)
+
+	t.Run("BadURL", func(t *testing.T) {
+		_, err := Load(ctx, "./testdata/config.yml")
+		require.Error(t, err)
+		require.Equal(t, UnknownSchemeError, err)
+	})
+
+	t.Run("BadFormat", func(t *testing.T) {
+		_, err := Load(ctx, fmt.Sprintf("file:///%s/testdata/config_bad.yml", cpath))
+		require.Error(t, err)
+		require.NotEqual(t, UnknownSchemeError, err)
+	})
+
+	t.Run("Ok", func(t *testing.T) {
+
+		cfg, err := Load(ctx, fmt.Sprintf("file:///%s/testdata/config.yml", cpath))
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+
+		require.Len(t, cfg.Feeds, 1)
+		feed := cfg.Feeds[0]
+		require.NotEmpty(t, feed.Source)
+		require.NotEmpty(t, feed.Category)
+		require.NotEmpty(t, feed.URL)
+		require.NotEmpty(t, feed.Translates)
+	})
+}

--- a/cmd/config/testdata/config.yml
+++ b/cmd/config/testdata/config.yml
@@ -1,0 +1,7 @@
+feeds:
+  - source: Helsingin Sanomat
+    category: City
+    url: https://www.hs.fi/rss/kaupunki.xml
+    translates:
+      - from: fi
+        to: en

--- a/cmd/config/testdata/config_bad.yml
+++ b/cmd/config/testdata/config_bad.yml
@@ -1,0 +1,1 @@
+non yaml format

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,17 +7,19 @@ import (
 )
 
 var rootFlags = struct {
-	verbose bool
+	verbose    bool
+	configFile string
 }{}
 
 func init() {
-	rootCmd.PersistentFlags().BoolVarP(
-		&rootFlags.verbose, "verbose", "v", false, "Verbose client output",
-	)
+	rootCmd.PersistentFlags().BoolVarP(&rootFlags.verbose, "verbose", "v", false, "Verbose client output")
+	rootCmd.PersistentFlags().StringVarP(&rootFlags.configFile, "config", "c", "file:///$(pwd)/config.yml", "Config file URI. Supported schemes: file://, gs://")
+	// _ = rootCmd.MarkPersistentFlagRequired("config")
 }
 
 var rootCmd = &cobra.Command{
-	Use: "a0feed",
+	Use:  "a0feed",
+	Long: `A0 Feed a news translation service`,
 }
 
 func Execute() {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module a0feed
 go 1.21.1
 
 require (
+	cloud.google.com/go/storage v1.30.1
 	cloud.google.com/go/translate v1.9.3
 	github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1
 	github.com/joho/godotenv v1.5.1
@@ -18,6 +19,7 @@ require (
 	cloud.google.com/go v0.110.8 // indirect
 	cloud.google.com/go/compute v1.23.1 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
+	cloud.google.com/go/iam v1.1.3 // indirect
 	cloud.google.com/go/longrunning v0.5.2 // indirect
 	github.com/PuerkitoBio/goquery v1.8.0 // indirect
 	github.com/andybalholm/cascadia v1.3.1 // indirect
@@ -25,6 +27,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect
+	github.com/google/uuid v1.4.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -42,6 +45,7 @@ require (
 	golang.org/x/sync v0.4.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
+	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/api v0.149.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20231016165738-49dd2c1f3d0b // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,12 @@ cloud.google.com/go/compute v1.23.1 h1:V97tBoDaZHb6leicZ1G6DLK2BAaZLJ/7+9BB/En3h
 cloud.google.com/go/compute v1.23.1/go.mod h1:CqB3xpmPKKt3OJpW2ndFIXnA9A4xAy/F3Xp1ixncW78=
 cloud.google.com/go/compute/metadata v0.2.3 h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGBW5aJ7UnBMY=
 cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2AawlZn8kiOGuCv6gTkwuA=
+cloud.google.com/go/iam v1.1.3 h1:18tKG7DzydKWUnLjonWcJO6wjSCAtzh4GcRKlH/Hrzc=
+cloud.google.com/go/iam v1.1.3/go.mod h1:3khUlaBXfPKKe7huYgEpDn6FtgRyMEqbkvBxrQyY5SE=
 cloud.google.com/go/longrunning v0.5.2 h1:u+oFqfEwwU7F9dIELigxbe0XVnBAo9wqMuQLA50CZ5k=
 cloud.google.com/go/longrunning v0.5.2/go.mod h1:nqo6DQbNV2pXhGDbDMoN2bWz68MjZUzqv2YttZiveCs=
+cloud.google.com/go/storage v1.30.1 h1:uOdMxAs8HExqBlnLtnQyP0YkvbiDpdGShGKtx6U/oNM=
+cloud.google.com/go/storage v1.30.1/go.mod h1:NfxhC0UJE1aXSx7CIIbCf7y9HKT7BiccwkR7+P7gN8E=
 cloud.google.com/go/translate v1.9.3 h1:t5WXTqlrk8VVJu/i3WrYQACjzYJiff5szARHiyqqPzI=
 cloud.google.com/go/translate v1.9.3/go.mod h1:Kbq9RggWsbqZ9W5YpM94Q1Xv4dshw/gr/SHfsl5yCZ0=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -55,9 +59,13 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/martian/v3 v3.3.2 h1:IqNFLAmvJOgVlpdEBiQbDc2EwKW77amAycfTuWKdfvw=
+github.com/google/martian/v3 v3.3.2/go.mod h1:oBOf6HBosgwRXnUGWUB05QECsc6uvmMiJ3+6W4l/CUk=
 github.com/google/s2a-go v0.1.7 h1:60BLSyTrOV4/haCDW4zb1guZItoSq8foHCXrAnjBo/o=
 github.com/google/s2a-go v0.1.7/go.mod h1:50CgR4k1jNlWBu4UfS4AcfhVe1r6pdZPygJ3R8F0Qdw=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.4.0 h1:MtMxsa51/r9yyhkyLsVeVt0B+BGQZzpQiTQ4eHZ8bc4=
+github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/enterprise-certificate-proxy v0.3.2 h1:Vie5ybvEvT75RniqhfFxPRy3Bf7vr3h0cechB90XaQs=
 github.com/googleapis/enterprise-certificate-proxy v0.3.2/go.mod h1:VLSiSSBs/ksPL8kq3OBOQ6WRI2QnaFynd1DCjZ62+V0=
 github.com/googleapis/gax-go/v2 v2.12.0 h1:A+gCJKdRfqXkr+BIRGtZLibNXf0m1f9E4HG56etFpas=
@@ -151,6 +159,8 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
+golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 google.golang.org/api v0.149.0 h1:b2CqT6kG+zqJIVKRQ3ELJVLN1PwHZ6DJ3dW8yl82rgY=
 google.golang.org/api v0.149.0/go.mod h1:Mwn1B7JTXrzXtnvmzQE2BD6bYZQ8DShKZDZbeN9I7qI=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=


### PR DESCRIPTION
Adding --config flag to specify config file URI to use. The source could be a local file system or Google Storage (S3 bucket).

```bash
# Loading from file system
./a0feed server --config file:///path/to/config.yaml
# Loading from Google cloud
./a0feed server --config gs://bucket/config.yaml
```