### PR TITLE
Adding app state cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Available environment variables for service run type:
 | `BCTR_MUTE_NOTIFICATIONS` | Disable sent notification to destinations. | `false` |
 | `BCTR_TELEGRAM_BOT_TOKEN` | Telegram bot token. |  |
 | `BCTR_SLACK_API_TOKEN` | Slack bot API token. |  |
+| `BCTR_STATE_TTL` | Application state TTL in seconds. | `86400` |
 
 \* Google Cloud Translation service requires `BCTR_GOOGLE_CLOUD_CREDS` or `GOOGLE_APPLICATION_CREDENTIALS` environment variable to be set.
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -126,6 +126,9 @@ var serverCmd = &cobra.Command{
 					if err := svc.Process(ctx); err != nil {
 						logger.Error("Failed to process data: ", err.Error())
 					}
+					if err := svc.CleanupState(ctx); err != nil {
+						logger.Error("Failed to cleanup state: ", err.Error())
+					}
 				case <-ctx.Done():
 					logger.Info("Stopping application")
 					ticker.Stop()

--- a/service/config.go
+++ b/service/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	// Do not send notifications
 	MuteNotifications bool   `envconfig:"MUTE_NOTIFICATIONS"`
 	GoogleCloudCreds  string `envconfig:"GOOGLE_CLOUD_CREDS"`
+	StateTTL          int    `envconfig:"STATE_TTL" default:"86400"`
 }
 
 func (c *Config) Validate() error {

--- a/service/state.go
+++ b/service/state.go
@@ -2,39 +2,80 @@ package service
 
 import (
 	"broadcaster/structs"
+	"context"
 	"sync"
 	"time"
 
 	"github.com/mmcdole/gofeed"
+	"go.uber.org/zap"
 )
 
-type State struct {
-	mu    *sync.RWMutex
-	items map[string]*time.Time
+type state struct {
+	logger *zap.SugaredLogger
+	mu     *sync.RWMutex
+	items  map[string]stateItem
 }
 
-func NewState() *State {
-	s := &State{
-		mu:    &sync.RWMutex{},
-		items: make(map[string]*time.Time),
+type stateItem struct {
+	Saved     time.Time
+	Published *time.Time
+}
+
+func newState(logger *zap.SugaredLogger) *state {
+	s := &state{
+		logger: logger.Named("state"),
+		mu:     &sync.RWMutex{},
+		items:  make(map[string]stateItem),
 	}
 	return s
 }
 
 func getId(feed structs.FeedConfig, item *gofeed.Item) string {
-	return feed.Source + "." + feed.Category + "." + item.GUID
+	return feed.GetId() + "." + item.GUID
 }
 
-func (s *State) Set(feed structs.FeedConfig, item *gofeed.Item) {
+func (s *state) set(feed structs.FeedConfig, item *gofeed.Item) {
+	now := time.Now().UTC()
 	s.mu.Lock()
-	s.items[getId(feed, item)] = item.PublishedParsed
+	s.items[getId(feed, item)] = stateItem{
+		Published: item.PublishedParsed,
+		Saved:     now,
+	}
 	s.mu.Unlock()
 }
 
-func (s *State) GetPubTime(feed structs.FeedConfig, item *gofeed.Item) *time.Time {
+func (s *state) getPubTime(feed structs.FeedConfig, item *gofeed.Item) *time.Time {
 	data, exists := s.items[getId(feed, item)]
 	if !exists {
 		return nil
 	}
-	return data
+	return data.Published
+}
+
+func (s *state) cleanup(ctx context.Context, ttl time.Duration) (int, error) {
+	deadline := time.Now().UTC().Add(-ttl)
+
+	s.logger.Debugf("Deadline: %v (-%v)", deadline, ttl)
+
+	var deleted int
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for k, v := range s.items {
+		ilogger := s.logger.With("id", k, "saved", v.Saved)
+
+		if !v.Saved.Before(deadline) {
+			ilogger.Debug("Skipping item")
+			continue
+		}
+
+		ilogger.Debug("Removing item")
+		delete(s.items, k)
+		deleted++
+	}
+
+	s.logger.Debug("State size: ", len(s.items))
+
+	return deleted, nil
 }


### PR DESCRIPTION
Cleaning up application state with each feed processing iteration.  State TTL configured with `BCTR_STATE_TTL` env, default to 24h.

Resolves #15 