### PR TITLE
Digitaocean app logging format

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Available environment variables for service run type:
 | ---- | ----------- | ------------- |
 | `BCTR_ENV` | Environment name / id. | `local` |
 | `BCTR_LOG_LEVEL` | Logging level. | `info` |
-| `BCTR_LOG_FORMAT` | Logging format. Options: `json`, `pretty`, `pretty_color` | `json` |
+| `BCTR_LOG_FORMAT` | Logging format. Options: `json`, `pretty`, `pretty_color`, `do_app` | `pretty_color` |
 | `BCTR_BOOTSTRAP_FILE` | Bootstrap config file path in uri format.<br>Example: `file:///path/to/config.yml` | |
 | `BCTR_TRANSLATOR_TYPE` | Translation service type. * | `google_cloud` |
 | `BCTR_GOOGLE_CLOUD_PROJECT_ID` | Google Cloud Project ID. | |

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -27,7 +27,7 @@ func init() {
 type serverConfig struct {
 	Env           string         `envconfig:"ENV" default:"local"`
 	LogLevel      string         `envconfig:"LOG_LEVEL" default:"info"`
-	LogFormat     logging.Format `envconfig:"LOG_FORMAT" default:"json"`
+	LogFormat     logging.Format `envconfig:"LOG_FORMAT" default:"pretty_color"`
 	BootstrapFile string         `envconfig:"BOOTSTRAP_FILE"`
 	StateTTL      int            `envconfig:"STATE_TTL" default:"86400"`
 	CheckInterval int            `envconfig:"CHECK_INTERVAL" default:"300"`
@@ -45,10 +45,6 @@ var serverCmd = &cobra.Command{
 		if err := envconfig.Process(info.EnvPrefix, &cfg); err != nil {
 			fmt.Printf("Can't load env: %s\n", err.Error())
 			os.Exit(1)
-		}
-		// Set color logs for the local development
-		if cfg.Env == "local" && cfg.LogFormat != "pretty" {
-			cfg.LogFormat = "pretty_color"
 		}
 
 		/* Logger */

--- a/utils/logging/logger.go
+++ b/utils/logging/logger.go
@@ -15,9 +15,10 @@ type contextKey string
 type Format string
 
 const (
-	FormatJSON        Format = "json"
-	FormatPretty      Format = "pretty"
-	FormatPrettyColor Format = "pretty_color"
+	FormatJSON            Format = "json"
+	FormatPretty          Format = "pretty"
+	FormatPrettyColor     Format = "pretty_color"
+	FormatDigitaloceanApp Format = "do_app"
 
 	// loggerKey points to the value in the context where the logger is stored.
 	loggerKey = contextKey("logger")
@@ -65,6 +66,26 @@ func NewLogger(level string, format Format) *zap.SugaredLogger {
 				LevelKey:       levelKey,
 				EncodeLevel:    zapcore.CapitalLevelEncoder,
 				TimeKey:        timeKey,
+				EncodeTime:     zapcore.ISO8601TimeEncoder,
+				EncodeDuration: zapcore.SecondsDurationEncoder,
+				EncodeCaller:   zapcore.ShortCallerEncoder,
+				LineEnding:     zapcore.DefaultLineEnding,
+			},
+			OutputPaths:      []string{"stdout"},
+			ErrorOutputPaths: []string{"stderr"},
+		}
+	case FormatDigitaloceanApp:
+		config = &zap.Config{
+			Level:       zap.NewAtomicLevelAt(toZapLevel(level)),
+			Development: false,
+			Encoding:    "console",
+			EncoderConfig: zapcore.EncoderConfig{
+				NameKey:        nameKey,
+				MessageKey:     messageKey,
+				StacktraceKey:  stacktraceKey,
+				LevelKey:       levelKey,
+				EncodeLevel:    zapcore.CapitalColorLevelEncoder,
+				TimeKey:        zapcore.OmitKey,
 				EncodeTime:     zapcore.ISO8601TimeEncoder,
 				EncodeDuration: zapcore.SecondsDurationEncoder,
 				EncodeCaller:   zapcore.ShortCallerEncoder,


### PR DESCRIPTION
Adding a new log format with an omitted timestamp for the Digitalocean 'Runtime Logs' view that already has timestamps.