### PR TITLE
Fixing slice bounds out of range panic

### DIFF
--- a/services/processer/service.go
+++ b/services/processer/service.go
@@ -165,14 +165,17 @@ func (s *Service) processFeed(ctx context.Context, feed structs.RssFeed) error {
 
 	logger.Debug("Parsing feed")
 
-	if feed.ItemsLimit == 0 {
-		feed.ItemsLimit = 10
-	}
-
 	fp := gofeed.NewParser()
 	parsed, err := fp.ParseURLWithContext(feed.URL, ctx)
 	if err != nil {
 		return fmt.Errorf("Failed to parse feed: %w", err)
+	}
+
+	if feed.ItemsLimit == 0 {
+		feed.ItemsLimit = 10
+	}
+	if feed.ItemsLimit > len(parsed.Items) {
+		feed.ItemsLimit = len(parsed.Items)
 	}
 
 	var pitems []*structs.RssFeedItem


### PR DESCRIPTION
Fixing cases when the items limit is bigger than the parsed items
```
[broadcaster] [2024-05-03 19:09:15] FATAL       Application panic       {"app": "broadcaster", "env": "prod", "release": "3fcdfad", "hash": "3fcdfad4c469c60b5da5c236d7dd9620e7640e1b", "panic": "runtime error: slice bounds out of range [:10] with capacity 4"}
[broadcaster] [2024-05-03 19:09:15] broadcaster/cmd.glob..func1.2
[broadcaster] [2024-05-03 19:09:15]     /app/cmd/server.go:83
[broadcaster] [2024-05-03 19:09:15] runtime.gopanic
[broadcaster] [2024-05-03 19:09:15]     /usr/local/go/src/runtime/panic.go:914
[broadcaster] [2024-05-03 19:09:15] runtime.goPanicSliceAcap
[broadcaster] [2024-05-03 19:09:15]     /usr/local/go/src/runtime/panic.go:140
[broadcaster] [2024-05-03 19:09:15] broadcaster/services/processer.(*Service).processFeed
[broadcaster] [2024-05-03 19:09:15]     /app/services/processer/service.go:180
[broadcaster] [2024-05-03 19:09:15] broadcaster/services/processer.(*Service).Process
[broadcaster] [2024-05-03 19:09:15]     /app/services/processer/service.go:150
[broadcaster] [2024-05-03 19:09:15] broadcaster/cmd.glob..func1
[broadcaster] [2024-05-03 19:09:15]     /app/cmd/server.go:123
[broadcaster] [2024-05-03 19:09:15] github.com/spf13/cobra.(*Command).execute
[broadcaster] [2024-05-03 19:09:15]     /go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:987
[broadcaster] [2024-05-03 19:09:15] github.com/spf13/cobra.(*Command).ExecuteC
[broadcaster] [2024-05-03 19:09:15]     /go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115
[broadcaster] [2024-05-03 19:09:15] github.com/spf13/cobra.(*Command).Execute
[broadcaster] [2024-05-03 19:09:15]     /go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039
[broadcaster] [2024-05-03 19:09:15] broadcaster/cmd.Execute
[broadcaster] [2024-05-03 19:09:15]     /app/cmd/root.go:15
[broadcaster] [2024-05-03 19:09:15] main.main
[broadcaster] [2024-05-03 19:09:15]     /app/main.go:6
[broadcaster] [2024-05-03 19:09:15] runtime.main
[broadcaster] [2024-05-03 19:09:15]     /usr/local/go/src/runtime/proc.go:267
```