### PR TITLE
Translations for each notification type

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ feeds:
     category: Latest
     url: https://dummyfeed.com/rss
     language: fi
-    translations:
-      - to: en
     notifications:
       - type: slack
         to: ["#general"]
       - type: telegram
         to: ["-1234567890","-1234567891"]
+        translate:
+          to: en
 ```
 
 ## Notifiers

--- a/services/housekeeper/service.go
+++ b/services/housekeeper/service.go
@@ -49,7 +49,7 @@ func (s *Service) CleanupFeedItems(ctx context.Context, ttl time.Duration) error
 	var deleted int
 
 	for _, item := range items {
-		ilogger := s.logger.With("guid", item.Id, "saved", item.Processed, "feed_id", item.FeedId)
+		ilogger := s.logger.With("item_id", item.Id, "saved", item.Processed, "feed_id", item.FeedId)
 		if !item.Processed.Before(deadline) {
 			ilogger.Debug("Skipping item cleanup")
 			continue

--- a/services/processer/config.go
+++ b/services/processer/config.go
@@ -26,7 +26,7 @@ func (c *Config) Validate() error {
 	if c.TranslatorType == TranslationTypeGC && c.GoogleCloudProjectId == "" {
 		return errors.New("Google Cloud Project ID is required")
 	}
-	if c.TelegramBotToken == "" {
+	if !c.MuteNotifications && c.TelegramBotToken == "" {
 		return errors.New("Telegram Bot Token is required")
 	}
 	return nil

--- a/services/processer/service_test.go
+++ b/services/processer/service_test.go
@@ -1,0 +1,172 @@
+package processer
+
+import (
+	"broadcaster/services/processer/translator"
+	"broadcaster/storages/memory"
+	"broadcaster/structs"
+	"broadcaster/utils/logging"
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Service for tests. Contains mock translator and disabled notifications.
+var tservice *Service
+
+func TestMain(m *testing.M) {
+	os.Exit(testMainWrapper(m))
+}
+
+func testMainWrapper(m *testing.M) int {
+	tlogger := logging.NewLogger("fatal", logging.FormatPretty)
+
+	tstorage := memory.NewStorage(memory.WithLogger(tlogger))
+
+	os.Setenv("BCTR_TRANSLATOR_TYPE", "mock")
+	os.Setenv("BCTR_MUTE_NOTIFICATIONS", "true")
+
+	s, err := NewService(tstorage, WithLogger(tlogger))
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	tservice = s
+
+	return m.Run()
+}
+
+func Test_Service_parseRssFeed(t *testing.T) {
+	ctx := context.TODO()
+
+	t.Run("nonExistsRss", func(t *testing.T) {
+		feed := structs.RssFeed{
+			Id:  "nonExistsRss",
+			URL: "https://fakeurl.local/rss.xml",
+		}
+		items, err := tservice.parseRssFeed(ctx, feed, 2*time.Second)
+		require.Error(t, err)
+		require.Nil(t, items)
+	})
+	t.Run("validRss", func(t *testing.T) {
+		feed := structs.RssFeed{
+			Id:       "validRss",
+			Source:   "ForTesting",
+			Category: "Dummy",
+			URL:      "https://www.hs.fi/rss/kaupunki.xml",
+			Language: "fi",
+		}
+		items, err := tservice.parseRssFeed(ctx, feed, 10*time.Second)
+		require.NoError(t, err)
+		require.NotNil(t, items)
+
+		ti := items[0]
+		require.NotEmpty(t, ti.Id, "Item ID should be fetched from the source RSS feed item")
+		require.Equal(t, feed.Id, ti.FeedId)
+		require.Equal(t, feed.Source, ti.Source)
+		require.NotEmpty(t, ti.Link)
+		require.Equal(t, feed.Language, ti.Language)
+		require.NotEmpty(t, ti.PubDate)
+		require.Empty(t, ti.Processed, "Processed should be empty on a parsing step")
+	})
+	t.Run("withItemsLimits", func(t *testing.T) {
+		feed := structs.RssFeed{
+			Id:         "withItemsLimits",
+			Source:     "ForTesting",
+			Category:   "Dummy",
+			URL:        "https://www.hs.fi/rss/kaupunki.xml",
+			ItemsLimit: 1,
+		}
+		items, err := tservice.parseRssFeed(ctx, feed, 10*time.Second)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(items), "Items limit should be respected")
+		require.NotEmpty(t, items[0])
+	})
+}
+
+func Test_Service_translateItems(t *testing.T) {
+	ctx := context.TODO()
+
+	feed := structs.RssFeed{
+		Id:       "validRss",
+		Source:   "ForTesting",
+		Category: "Dummy",
+		URL:      "https://fakeurl.local/rss.xml",
+		Language: "en",
+		Notifications: []structs.RssFeedNotification{
+			{
+				Type:      "slack",
+				To:        []string{"slack1", "slack2"},
+				Translate: structs.RssFeedTranslation{To: "fr"},
+			},
+			{
+				Type:      "slack",
+				To:        []string{"slack3"},
+				Translate: structs.RssFeedTranslation{To: "fr"},
+			},
+		},
+	}
+
+	items := []structs.RssFeedItem{
+		{
+			Id:     "translationError",
+			FeedId: "validRss",
+			Link:   translator.MockURLForError,
+		},
+		{
+			Id:       "sameLanguage",
+			FeedId:   "validRss",
+			Language: "fr",
+		},
+		{
+			Id:          "validTranslation",
+			FeedId:      "validRss",
+			Source:      "ForTesting",
+			Title:       "Hello World",
+			Description: "This is a test",
+			Link:        "https://www.example.com",
+		},
+	}
+
+	tservice.translateItems(ctx, feed, items...)
+
+	// TODO: Create separate test for this
+	// require.Equal(
+	// 	t, len(feed.GetTranslatonsLang()), len(tservice.translations),
+	// 	"Only requested languages translates items should be stored in the cache",
+	// )
+
+	require.Nil(t, tservice.getTranslation("translationError", "en"), "Item should not be stored in the cache on error")
+	require.Nil(t, tservice.getTranslation("sameLanguage", "en"), "Item should not be stored in the cache on error")
+	require.NotNil(t, tservice.getTranslation("validTranslation", "en"), "Item should be stored in the cache on error")
+}
+
+func Test_Service_translateItem(t *testing.T) {
+	ctx := context.TODO()
+
+	t.Run("translationError", func(t *testing.T) {
+		item := &structs.RssFeedItem{
+			Id:   "translationError",
+			Link: translator.MockURLForError,
+		}
+		err := tservice.translateItem(ctx, item, "fi", "en")
+		require.Error(t, err)
+	})
+	t.Run("validTranslation", func(t *testing.T) {
+		item := &structs.RssFeedItem{
+			Id:          "validTranslation",
+			FeedId:      "validRss",
+			Source:      "ForTesting",
+			Title:       "Hello World",
+			Description: "This is a test",
+			Link:        "https://www.example.com",
+			Language:    "fi",
+			PubDate:     time.Now(),
+		}
+		err := tservice.translateItem(ctx, item, "fi", "en")
+		require.NoError(t, err)
+	})
+}

--- a/services/processer/service_test.go
+++ b/services/processer/service_test.go
@@ -22,7 +22,7 @@ func TestMain(m *testing.M) {
 }
 
 func testMainWrapper(m *testing.M) int {
-	tlogger := logging.NewLogger("fatal", logging.FormatPretty)
+	tlogger := logging.NewLogger("debug", logging.FormatPretty)
 
 	tstorage := memory.NewStorage(memory.WithLogger(tlogger))
 
@@ -139,9 +139,9 @@ func Test_Service_translateItems(t *testing.T) {
 	// 	"Only requested languages translates items should be stored in the cache",
 	// )
 
-	require.Nil(t, tservice.getTranslation("translationError", "en"), "Item should not be stored in the cache on error")
-	require.Nil(t, tservice.getTranslation("sameLanguage", "en"), "Item should not be stored in the cache on error")
-	require.NotNil(t, tservice.getTranslation("validTranslation", "en"), "Item should be stored in the cache on error")
+	require.Nil(t, tservice.getTranslation("translationError", "fr"), "Item should not be stored in the cache on error")
+	require.Nil(t, tservice.getTranslation("sameLanguage", "fr"), "Item should not be stored in the cache on error")
+	require.NotNil(t, tservice.getTranslation("validTranslation", "fr"), "Translated item should be stored in the cache")
 }
 
 func Test_Service_translateItem(t *testing.T) {

--- a/services/processer/translator/mock.go
+++ b/services/processer/translator/mock.go
@@ -2,6 +2,7 @@ package translator
 
 import (
 	"context"
+	"errors"
 )
 
 // Validates interface compliance
@@ -14,7 +15,13 @@ func NewMockTranslator() *MockTranslator {
 	return &MockTranslator{}
 }
 
+// URL to trigger error in mock translator.
+var MockURLForError = "https://fakeurl.local/rss.xml"
+
 func (t *MockTranslator) Translate(ctx context.Context, r TranlsationRequest) (*TranlsationResponce, error) {
+	if r.Link == MockURLForError {
+		return nil, errors.New("mock error")
+	}
 	return &TranlsationResponce{
 		Title:       r.Text[0],
 		Description: r.Text[1],

--- a/storages/testdata/bootstrap_ok.yml
+++ b/storages/testdata/bootstrap_ok.yml
@@ -3,5 +3,8 @@ feeds:
     category: City
     url: https://www.hs.fi/rss/kaupunki.xml
     language: fi
-    translations:
-      - to: en
+    notifications:
+      - type: telegram
+        to: ["-123"]
+        translate:
+          to: en

--- a/structs/feeds.go
+++ b/structs/feeds.go
@@ -1,6 +1,9 @@
 package structs
 
-import "time"
+import (
+	"slices"
+	"time"
+)
 
 type RssFeed struct {
 	Id            string
@@ -10,17 +13,18 @@ type RssFeed struct {
 	Language      string
 	ItemsLimit    int
 	Notifications []RssFeedNotification
-	Translations  []RssFeedTranslation
 }
 
 type RssFeedNotification struct {
-	Type  string
-	To    []string
-	Muted bool
+	Type      string
+	To        []string
+	Muted     bool
+	Translate RssFeedTranslation
 }
 
 type RssFeedTranslation struct {
-	To string
+	From string
+	To   string
 }
 
 type RssFeedItem struct {
@@ -34,4 +38,15 @@ type RssFeedItem struct {
 	Language    string
 	PubDate     time.Time // Publication date (from the feed)
 	Processed   time.Time // When the item was processed by the service
+}
+
+// Returns a list of languages to which the feed items should be translated.
+func (c RssFeed) GetTranslatonsLang() []string {
+	var result []string
+	for _, n := range c.Notifications {
+		if n.Translate.To != "" && !slices.Contains(result, n.Translate.To) {
+			result = append(result, n.Translate.To)
+		}
+	}
+	return result
 }


### PR DESCRIPTION
Move the translation type specification to each feed notification type instead of a global setting. Which also improves the performance of the service by reusing already translated items for different notification channels.

Tests have also been improved and added.