### PR TITLE
Uploading app binaries into release assets

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -1,15 +1,11 @@
-name: Release
-
+name: Assets
 on:
   release:
-    types: [created]
-
+    types: [published]
   pull_request:
-    branches:
-      - main
-
+    branches: [main]
 jobs:
-  assets:
+  build:
     strategy:
       matrix:
         GOOS: [linux, darwin]
@@ -27,7 +23,8 @@ jobs:
         with:
           go-version: '1.21'
 
-      - id: env
+      - name: Setup environment
+        id: env
         run: |
           if [[ "${{ github.event.release.tag_name }}" == "" ]]; then
             tag=$(git rev-parse --short HEAD)
@@ -38,10 +35,9 @@ jobs:
 
       - name: Build binaries
         run: |
-
           make build BINARY=broadcaster-${{ steps.env.outputs.tag }}-$GOOS-$GOARCH
 
-      - name: Upload Release Asset
+      - name: Upload Release Assets
         if: github.event_name == 'release'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -38,7 +38,7 @@ jobs:
           make build BINARY=broadcaster-${{ steps.env.outputs.tag }}-$GOOS-$GOARCH
 
       - name: Upload Release Assets
-        if: github.event_name == 'release'
+        if: github.event.release.tag_name != ''
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release
+
+on:
+  release:
+    types: [created]
+
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  assets:
+    strategy:
+      matrix:
+        GOOS: [linux, darwin]
+        GOARCH: [amd64, arm64]
+    runs-on: ubuntu-latest
+    env:
+      GOOS: ${{ matrix.GOOS }}
+      GOARCH: ${{ matrix.GOARCH }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+
+      - id: env
+        run: |
+          if [[ -z ${{ github.event.release.tag_name }} ]]; then
+            tag=$(git rev-parse --short HEAD)
+          else
+            tag=${{ github.event.release.tag_name }}
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Build binaries
+        run: |
+
+          make build BINARY=broadcaster-${{ steps.env.outputs.tag }}-$GOOS-$GOARCH
+
+      - name: Upload Release Asset
+        if: github.event_name == 'release'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ steps.env.outputs.tag }} \
+            ./bin/broadcaster-${{ steps.env.outputs.tag }}-$GOOS-$GOARCH \
+            --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
 
       - id: env
         run: |
-          if [[ -z ${{ github.event.release.tag_name }} ]]; then
+          if [[ "${{ github.event.release.tag_name }}" == "" ]]; then
             tag=$(git rev-parse --short HEAD)
           else
             tag=${{ github.event.release.tag_name }}

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,10 @@ GREEN :=\033[0;32m
 
 APP       := broadcaster
 BINARY    ?= $(APP)
-# BINARY    ?= $(APP)-$(RELEASE)_$(GOARCH)_$(GOOS)
 RELEASE   ?= $(shell git rev-parse --short HEAD)
 COMMIT    := $(shell git rev-parse HEAD)
 DATE      ?= $(shell date '+%Y-%m-%d_%H:%M:%S')
-BUILD_NUM ?= 
+BUILD_NUM ?=
 
 BIN_DIR   := bin
 TESTS_DIR := tests


### PR DESCRIPTION
Adding a workflow that builds binaries for various OS and architectures and uploads them to the assets on a new GitHub Release.

Closes https://github.com/dlampsi/broadcaster/issues/46